### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ echo "curl"
 RUN curl -sL https://deb.nodesource.com/setup | bash -
 
 echo "apt-get"
-RUN apt-get -y install nodejs
+RUN apt-get --no-install-recommends install -y install nodejs
 
 
 RUN mkdir -p /usr/src/app

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,7 +82,7 @@ Vagrant.configure("2") do |config|
   # documentation for more information about their specific syntax and use.
   # config.vm.provision "shell", inline: <<-SHELL
   #   apt-get update
-  #   apt-get install -y apache2
+  #   apt-get --no-install-recommends install -y apache2
   # SHELL
   config.vm.provision "file", source: "vagrant/bash_aliases", destination: ".bash_aliases"
 

--- a/docker/distill/Dockerfile
+++ b/docker/distill/Dockerfile
@@ -16,14 +16,14 @@
 FROM python:2
 
 # install system wide deps
-RUN apt-get -yqq update
+RUN apt-get --no-install-recommends install -yqq update
 
 # Set the work directory
 RUN mkdir -p /usr/src
 WORKDIR /usr/src
 
 # Install git
-##RUN sudo -E apt-get -yqq install \
+##RUN sudo -E apt-get --no-install-recommends install -yqq install \
   ##git
 
 # Clone Distill

--- a/docker/kibana/Dockerfile
+++ b/docker/kibana/Dockerfile
@@ -17,8 +17,8 @@
 FROM ubuntu:16.04
 
 # install system wide deps
-RUN apt-get -yqq update
-RUN apt-get -yqq install netcat
+RUN apt-get --no-install-recommends install -yqq update
+RUN apt-get --no-install-recommends install -yqq install netcat
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
@@ -29,8 +29,8 @@ RUN echo "deb $KIBANA_REPO_BASE stable main" > /etc/apt/sources.list.d/kibana.li
 
 # install kibana
 RUN set -x \
-	&& apt-get -yqq update \
-	&& apt-get -yqq install --no-install-recommends kibana=$KIBANA_VERSION \
+	&& apt-get --no-install-recommends install -yqq update \
+	&& apt-get --no-install-recommends install -yqq install --no-install-recommends kibana=$KIBANA_VERSION \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PATH /opt/kibana/bin:$PATH

--- a/docker/logstash/Dockerfile
+++ b/docker/logstash/Dockerfile
@@ -17,9 +17,9 @@
 FROM ubuntu:16.04
 
 # install system wide deps
-RUN apt-get -yqq update
-RUN apt-get -yqq install openjdk-8-jre
-RUN apt-get -yqq install wget 
+RUN apt-get --no-install-recommends install -yqq update
+RUN apt-get --no-install-recommends install -yqq install openjdk-8-jre
+RUN apt-get --no-install-recommends install -yqq install wget 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
 ENV LOGSTASH_VERSION 1:2.3.4-1
@@ -29,8 +29,8 @@ RUN echo "deb $LOGSTASH_REPO_BASE stable main" > /etc/apt/sources.list.d/logstas
 
 # install logstash
 RUN set -x \
-	&& apt-get -yqq update \
-	&& apt-get -yqq install --no-install-recommends logstash=$LOGSTASH_VERSION \
+	&& apt-get --no-install-recommends install -yqq update \
+	&& apt-get --no-install-recommends install -yqq install --no-install-recommends logstash=$LOGSTASH_VERSION \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV PATH /opt/logstash/bin:$PATH

--- a/docker/tap/Dockerfile
+++ b/docker/tap/Dockerfile
@@ -17,14 +17,14 @@ FROM python:3.4
 MAINTAINER Michelle Beard <msbeard@apache.org>
 
 # Install system wide dependencies
-RUN apt-get -yqq update && apt-get -yqq install \
+RUN apt-get --no-install-recommends install -yqq update && apt-get --no-install-recommends install -yqq install \
 	curl \
 	sudo
 
 # Install NodeJS 4.x
 RUN curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
 
-RUN sudo -E apt-get -yqq install \
+RUN sudo -E apt-get --no-install-recommends install -yqq install \
 	nodejs \
 	build-essential 
 
@@ -36,7 +36,7 @@ WORKDIR /usr/src
 RUN npm install -g bower gulp
 
 # Install git
-RUN sudo -E apt-get -yqq install \
+RUN sudo -E apt-get --no-install-recommends install -yqq install \
   git
 
 # Clone TAP

--- a/docker/webserver/Dockerfile
+++ b/docker/webserver/Dockerfile
@@ -16,8 +16,8 @@
 FROM python:2
 
 # install system wide deps
-RUN apt-get -yqq update
-RUN apt-get -yqq install nginx
+RUN apt-get --no-install-recommends install -yqq update
+RUN apt-get --no-install-recommends install -yqq install nginx
 
 # Install Supervisord
 RUN pip install supervisor-stdout

--- a/vagrant/provision_as_root.sh
+++ b/vagrant/provision_as_root.sh
@@ -22,7 +22,7 @@ sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 sudo apt-get update
 
-sudo apt-get install -y postgresql-9.5 postgresql-contrib-9.5 postgresql-server-dev-9.5 libpq-dev
+sudo apt-get --no-install-recommends install -y postgresql-9.5 postgresql-contrib-9.5 postgresql-server-dev-9.5 libpq-dev
 PGSQL_DB_PASSWORD="Dr@p3rUs3r"
 sudo -u postgres psql -c "CREATE DATABASE tapdb"
 sudo -u postgres psql -c "CREATE USER tapuser WITH PASSWORD '$PGSQL_DB_PASSWORD'"
@@ -31,11 +31,11 @@ sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE tapdb TO tapuser"
 # Essentials
 #sudo apt-get update -q
 echo "Installing Essentials ..."
-sudo apt-get install -y git build-essential libssl-dev
+sudo apt-get --no-install-recommends install -y git build-essential libssl-dev
 echo "Done"
 
 # Python
-sudo apt-get install -y python-pip python-dev python3-dev 
+sudo apt-get --no-install-recommends install -y python-pip python-dev python3-dev 
 #sudo pip install virtualenv virtualenvwrapper
 
 echo "Installing Python virtualenv ..."


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>